### PR TITLE
Add scoring and local leaderboard

### DIFF
--- a/game.js
+++ b/game.js
@@ -3,6 +3,10 @@ const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 let lastTime = 0;
 
+let score = 0;
+let gameRunning = true;
+let paused = false;
+
 const player = new Player();
 const map = new GameMap();
 const base = new Base();
@@ -31,9 +35,16 @@ function update(dt) {
     enemies.forEach(e => e.update(dt, player));
     // remove dead enemies
     for (let i = enemies.length -1; i >=0; i--) {
-        if (enemies[i].dead) enemies.splice(i,1);
+        if (enemies[i].dead) {
+            enemies.splice(i,1);
+            score++;
+        }
     }
     if (enemies.length === 0) spawnWave();
+
+    if (player.hp <= 0 && gameRunning) {
+        gameOver();
+    }
 }
 
 function draw() {
@@ -42,16 +53,70 @@ function draw() {
     base.draw(ctx);
     enemies.forEach(e => e.draw(ctx));
     player.draw(ctx);
-    drawHUD(player, wave);
+    drawHUD(player, wave, score);
 }
 
 function gameLoop(timestamp) {
-    const dt = (timestamp - lastTime) / 1000;
-    lastTime = timestamp;
-    update(dt);
-    draw();
+    if (!gameRunning) return;
+    if (!paused) {
+        const dt = (timestamp - lastTime) / 1000;
+        lastTime = timestamp;
+        update(dt);
+        draw();
+    }
     requestAnimationFrame(gameLoop);
 }
+
+function saveScore(name, value) {
+    const raw = localStorage.getItem('chronovoid-leaderboard');
+    const board = raw ? JSON.parse(raw) : [];
+    board.push({name, score: value});
+    board.sort((a,b) => b.score - a.score);
+    localStorage.setItem('chronovoid-leaderboard', JSON.stringify(board));
+    return board;
+}
+
+function showLeaderboard(entries) {
+    const boardEl = document.getElementById('leaderboard');
+    boardEl.innerHTML = '<h2>Leaderboard</h2>';
+    const list = document.createElement('ol');
+    entries.forEach(e => {
+        const li = document.createElement('li');
+        li.textContent = `${e.name}: ${e.score}`;
+        list.appendChild(li);
+    });
+    boardEl.appendChild(list);
+    boardEl.style.display = 'block';
+}
+
+function gameOver() {
+    gameRunning = false;
+    const name = prompt('Game Over! Enter your name:') || 'Anonymous';
+    const lb = saveScore(name, score);
+    showLeaderboard(lb);
+}
+
+function togglePause() {
+    if (!gameRunning) return;
+    paused = !paused;
+    const overlay = document.getElementById('pauseOverlay');
+    overlay.style.display = paused ? 'block' : 'none';
+    if (!paused) {
+        lastTime = performance.now();
+    }
+}
+
+function restartGame() {
+    window.location.reload();
+}
+
+window.addEventListener('keydown', e => {
+    if (e.key.toLowerCase() === 'p') {
+        togglePause();
+    } else if (e.key.toLowerCase() === 'r') {
+        restartGame();
+    }
+});
 
 loadSave();
 spawnWave();

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 <body>
     <canvas id="gameCanvas"></canvas>
     <div id="hud"></div>
+    <div id="leaderboard"></div>
+    <div id="pauseOverlay">Paused - Press P to resume or R to restart</div>
     <script src="ui/joystick.js"></script>
     <script src="ui/button.js"></script>
     <script src="ui/hud.js"></script>

--- a/style.css
+++ b/style.css
@@ -20,3 +20,28 @@ body {
     padding: 10px;
     z-index: 10;
 }
+
+#leaderboard {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0,0,0,0.8);
+    padding: 20px;
+    border: 1px solid #0f0;
+    display: none;
+    z-index: 20;
+}
+
+#pauseOverlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(0,0,0,0.8);
+    padding: 20px;
+    border: 1px solid #0f0;
+    display: none;
+    z-index: 20;
+    text-align: center;
+}

--- a/ui/hud.js
+++ b/ui/hud.js
@@ -1,4 +1,4 @@
-function drawHUD(player, wave) {
+function drawHUD(player, wave, score) {
     const hud = document.getElementById('hud');
-    hud.textContent = `Health: ${player.hp} | Energy: ${Math.floor(player.energy)} | Wave: ${wave}`;
+    hud.textContent = `Health: ${player.hp} | Energy: ${Math.floor(player.energy)} | Wave: ${wave} | Score: ${score}`;
 }


### PR DESCRIPTION
## Summary
- track enemy kills as score
- detect player death and halt loop
- prompt player for name at game over and store score in `localStorage`
- display leaderboard on screen
- include leaderboard element and style
- allow pausing with `P` and restarting with `R`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840a0dd81cc8333bc99503b73f43513