### PR TITLE
Fix duplicate restartGame function

### DIFF
--- a/game.js
+++ b/game.js
@@ -125,9 +125,6 @@ function togglePause() {
     }
 }
 
-function restartGame() {
-    window.location.reload();
-}
 
 window.addEventListener('keydown', e => {
     if (e.key.toLowerCase() === 'p') {


### PR DESCRIPTION
## Summary
- remove duplicate `restartGame` definition so pause and restart buttons use the same logic

## Testing
- `node --check game.js && node --check logic/base.js`
- `npx jshint game.js logic/*.js ui/*.js > /tmp/jshint.log`

------
https://chatgpt.com/codex/tasks/task_e_6840bdcd28b083339ba3b95509c559f4